### PR TITLE
Expose backup vault soft delete and storage type related variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
+# Unreleased
+
+Added:
+  * GH-3: Expose `storage_mode_type`, `cross_region_restore_enabled` and `soft_delete_enabled` vault variables
+
 # v6.1.0 - 2022-08-05
 
 Breaking
-  * AZ-807: use native Azure resource to create Data Collection Rule
+  * AZ-807: Use native Azure resource to create Data Collection Rule
 
 Fixed
   * AZ-809: Update examples to fix CI with latest tflint rules

--- a/README.md
+++ b/README.md
@@ -171,10 +171,13 @@ No resources.
 | logs\_retention\_days | Number of days to keep logs on storage account | `number` | `30` | no |
 | name\_prefix | Optional prefix for the generated name | `string` | `""` | no |
 | name\_suffix | Optional suffix for the generated name | `string` | `""` | no |
+| recovery\_vault\_cross\_region\_restore\_enabled | Is cross region restore enabled for this Vault? Only can be `true`, when `storage_mode_type` is `GeoRedundant`. Defaults to `false`. | `bool` | `false` | no |
 | recovery\_vault\_custom\_name | Azure Recovery Vault custom name. Empty by default, using naming convention. | `string` | `""` | no |
 | recovery\_vault\_extra\_tags | Extra tags to add to recovery vault | `map(string)` | `{}` | no |
 | recovery\_vault\_identity\_type | Azure Recovery Vault identity type. Possible values include: `null`, `SystemAssigned`. Default to `SystemAssigned`. | `string` | `"SystemAssigned"` | no |
 | recovery\_vault\_sku | Azure Recovery Vault SKU. Possible values include: `Standard`, `RS0`. Default to `Standard`. | `string` | `"Standard"` | no |
+| recovery\_vault\_soft\_delete\_enabled | Is soft delete enable for this Vault? Defaults to `true`. | `bool` | `true` | no |
+| recovery\_vault\_storage\_mode\_type | The storage type of the Recovery Services Vault. Possible values are `GeoRedundant`, `LocallyRedundant` and `ZoneRedundant`. Defaults to `GeoRedundant`. | `string` | `"GeoRedundant"` | no |
 | resource\_group\_name | Resource Group the resources will belong to | `string` | n/a | yes |
 | stack | Stack name | `string` | n/a | yes |
 | update\_management\_duration | To set the maintenance window, the duration must be a minimum of 30 minutes and less than 6 hours. The last 20 minutes of the maintenance window is dedicated for machine restart and any remaining updates will not be started once this interval is reached. In-progress updates will finish being applied. This parameter needs to be specified using the format PT[n]H[n]M[n]S as per ISO8601. Defaults to 2 hours (PT2H). | `string` | `"PT2H"` | no |

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ No resources.
 | logs\_retention\_days | Number of days to keep logs on storage account | `number` | `30` | no |
 | name\_prefix | Optional prefix for the generated name | `string` | `""` | no |
 | name\_suffix | Optional suffix for the generated name | `string` | `""` | no |
-| recovery\_vault\_cross\_region\_restore\_enabled | Is cross region restore enabled for this Vault? Only can be `true`, when `storage_mode_type` is `GeoRedundant`. Defaults to `false`. | `bool` | `false` | no |
+| recovery\_vault\_cross\_region\_restore\_enabled | Is cross region restore enabled for this Vault? Only can be `true`, when `storage_mode_type` is `GeoRedundant`. Defaults to `false`. | `bool` | `true` | no |
 | recovery\_vault\_custom\_name | Azure Recovery Vault custom name. Empty by default, using naming convention. | `string` | `""` | no |
 | recovery\_vault\_extra\_tags | Extra tags to add to recovery vault | `map(string)` | `{}` | no |
 | recovery\_vault\_identity\_type | Azure Recovery Vault identity type. Possible values include: `null`, `SystemAssigned`. Default to `SystemAssigned`. | `string` | `"SystemAssigned"` | no |

--- a/modules.tf
+++ b/modules.tf
@@ -16,10 +16,13 @@ module "backup" {
   default_tags_enabled = var.default_tags_enabled
   extra_tags           = var.extra_tags
 
-  recovery_vault_custom_name   = var.recovery_vault_custom_name
-  recovery_vault_sku           = var.recovery_vault_sku
-  recovery_vault_identity_type = var.recovery_vault_identity_type
-  recovery_vault_extra_tags    = var.recovery_vault_extra_tags
+  recovery_vault_custom_name                  = var.recovery_vault_custom_name
+  recovery_vault_sku                          = var.recovery_vault_sku
+  recovery_vault_identity_type                = var.recovery_vault_identity_type
+  recovery_vault_storage_mode_type            = var.recovery_vault_storage_mode_type
+  recovery_vault_cross_region_restore_enabled = var.recovery_vault_cross_region_restore_enabled
+  recovery_vault_soft_delete_enabled          = var.recovery_vault_soft_delete_enabled
+  recovery_vault_extra_tags                   = var.recovery_vault_extra_tags
 
   vm_backup_policy_custom_name     = var.vm_backup_policy_custom_name
   vm_backup_policy_timezone        = var.vm_backup_policy_timezone

--- a/modules/backup/README.md
+++ b/modules/backup/README.md
@@ -121,10 +121,13 @@ module "az-backup" {
 | logs\_retention\_days | Number of days to keep logs on storage account | `number` | `30` | no |
 | name\_prefix | Optional prefix for the generated name | `string` | `""` | no |
 | name\_suffix | Optional suffix for the generated name | `string` | `""` | no |
+| recovery\_vault\_cross\_region\_restore\_enabled | Is cross region restore enabled for this Vault? Only can be `true`, when `storage_mode_type` is `GeoRedundant`. Defaults to `false`. | `bool` | `false` | no |
 | recovery\_vault\_custom\_name | Azure Recovery Vault custom name. Empty by default, using naming convention. | `string` | `""` | no |
 | recovery\_vault\_extra\_tags | Extra tags to add to recovery vault | `map(string)` | `{}` | no |
 | recovery\_vault\_identity\_type | Azure Recovery Vault identity type. Possible values include: `null`, `SystemAssigned`. Default to `SystemAssigned`. | `string` | `"SystemAssigned"` | no |
 | recovery\_vault\_sku | Azure Recovery Vault SKU. Possible values include: `Standard`, `RS0`. Default to `Standard`. | `string` | `"Standard"` | no |
+| recovery\_vault\_soft\_delete\_enabled | Is soft delete enable for this Vault? Defaults to `true`. | `bool` | `true` | no |
+| recovery\_vault\_storage\_mode\_type | The storage type of the Recovery Services Vault. Possible values are `GeoRedundant`, `LocallyRedundant` and `ZoneRedundant`. Defaults to `GeoRedundant`. | `string` | `"GeoRedundant"` | no |
 | resource\_group\_name | Resource Group the resources will belong to | `string` | n/a | yes |
 | stack | Stack name | `string` | n/a | yes |
 | use\_caf\_naming | Use the Azure CAF naming provider to generate default resource name. `recovery_vault_custom_name` override this if set. Legacy default name is used if this is set to `false`. | `bool` | `true` | no |

--- a/modules/backup/README.md
+++ b/modules/backup/README.md
@@ -121,7 +121,7 @@ module "az-backup" {
 | logs\_retention\_days | Number of days to keep logs on storage account | `number` | `30` | no |
 | name\_prefix | Optional prefix for the generated name | `string` | `""` | no |
 | name\_suffix | Optional suffix for the generated name | `string` | `""` | no |
-| recovery\_vault\_cross\_region\_restore\_enabled | Is cross region restore enabled for this Vault? Only can be `true`, when `storage_mode_type` is `GeoRedundant`. Defaults to `false`. | `bool` | `false` | no |
+| recovery\_vault\_cross\_region\_restore\_enabled | Is cross region restore enabled for this Vault? Only can be `true`, when `storage_mode_type` is `GeoRedundant`. Defaults to `false`. | `bool` | `true` | no |
 | recovery\_vault\_custom\_name | Azure Recovery Vault custom name. Empty by default, using naming convention. | `string` | `""` | no |
 | recovery\_vault\_extra\_tags | Extra tags to add to recovery vault | `map(string)` | `{}` | no |
 | recovery\_vault\_identity\_type | Azure Recovery Vault identity type. Possible values include: `null`, `SystemAssigned`. Default to `SystemAssigned`. | `string` | `"SystemAssigned"` | no |

--- a/modules/backup/r-backup.tf
+++ b/modules/backup/r-backup.tf
@@ -5,6 +5,10 @@ resource "azurerm_recovery_services_vault" "vault" {
 
   sku = var.recovery_vault_sku
 
+  storage_mode_type            = var.recovery_vault_storage_mode_type
+  cross_region_restore_enabled = var.recovery_vault_cross_region_restore_enabled
+  soft_delete_enabled          = var.recovery_vault_soft_delete_enabled
+
   dynamic "identity" {
     for_each = toset(var.recovery_vault_identity_type != null ? ["fake"] : [])
     content {

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -42,6 +42,24 @@ variable "recovery_vault_sku" {
   default     = "Standard"
 }
 
+variable "recovery_vault_storage_mode_type" {
+  description = "The storage type of the Recovery Services Vault. Possible values are `GeoRedundant`, `LocallyRedundant` and `ZoneRedundant`. Defaults to `GeoRedundant`."
+  type        = string
+  default     = "GeoRedundant"
+}
+
+variable "recovery_vault_cross_region_restore_enabled" {
+  description = "Is cross region restore enabled for this Vault? Only can be `true`, when `storage_mode_type` is `GeoRedundant`. Defaults to `false`."
+  type        = bool
+  default     = false
+}
+
+variable "recovery_vault_soft_delete_enabled" {
+  description = "Is soft delete enable for this Vault? Defaults to `true`."
+  type        = bool
+  default     = true
+}
+
 variable "recovery_vault_identity_type" {
   description = "Azure Recovery Vault identity type. Possible values include: `null`, `SystemAssigned`. Default to `SystemAssigned`."
   type        = string

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -51,7 +51,7 @@ variable "recovery_vault_storage_mode_type" {
 variable "recovery_vault_cross_region_restore_enabled" {
   description = "Is cross region restore enabled for this Vault? Only can be `true`, when `storage_mode_type` is `GeoRedundant`. Defaults to `false`."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "recovery_vault_soft_delete_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,7 @@ variable "recovery_vault_storage_mode_type" {
 variable "recovery_vault_cross_region_restore_enabled" {
   description = "Is cross region restore enabled for this Vault? Only can be `true`, when `storage_mode_type` is `GeoRedundant`. Defaults to `false`."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "recovery_vault_soft_delete_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,24 @@ variable "recovery_vault_identity_type" {
   default     = "SystemAssigned"
 }
 
+variable "recovery_vault_storage_mode_type" {
+  description = "The storage type of the Recovery Services Vault. Possible values are `GeoRedundant`, `LocallyRedundant` and `ZoneRedundant`. Defaults to `GeoRedundant`."
+  type        = string
+  default     = "GeoRedundant"
+}
+
+variable "recovery_vault_cross_region_restore_enabled" {
+  description = "Is cross region restore enabled for this Vault? Only can be `true`, when `storage_mode_type` is `GeoRedundant`. Defaults to `false`."
+  type        = bool
+  default     = false
+}
+
+variable "recovery_vault_soft_delete_enabled" {
+  description = "Is soft delete enable for this Vault? Defaults to `true`."
+  type        = bool
+  default     = true
+}
+
 ###############################
 # VM Backup
 ###############################


### PR DESCRIPTION
For some business and test cases, one don't want/can't have e.g. the `storage_mode_type` set to `GeoRedundant`.